### PR TITLE
 Revert double quotes in names back to apostrophes

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
 					<li><a href="https://mattcrouch.net">Matt Crouch</a></li>
 					<li><a href="https://twitter.com/vcurd">Vaughan Curd</a></li>
 					<li><a href="https://devmarketer.io">J. Alexander Curtis</a></li>
-					<li><a href="https://www.lovelldsouza.com">Lovell D"souza</a></li>
+					<li><a href="https://www.lovelldsouza.com">Lovell D'souza</a></li>
 					<li><a href="https://www.baliome.ga">Nurul Izwan Dahlan</a></li>
 					<li><a href="https://www.bram.us/">Bram Van Damme</a></li>
 					<li><a href="https://twitter.com/jordandanford">Jordan Danford</a></li>
@@ -361,9 +361,9 @@
 					<li><a href="https://wietseneven.com">Wietse Neven</a></li>
 					<li><a href="https://twitter.com/nicknisi">Nick Nisi</a></li>
 					<li><a href="https://twitter.com/timnovis">Tim Novis</a></li>
-					<li><a href="https://tactile.co.za/">Shaun O"Connell</a></li>
-					<li><a href="http://scottohara.me/">Scott O"Hara</a></li>
-					<li><a href="https://peteroshaughnessy.com">Peter O"Shaughnessy</a></li>
+					<li><a href="https://tactile.co.za/">Shaun O'Connell</a></li>
+					<li><a href="http://scottohara.me/">Scott O'Hara</a></li>
+					<li><a href="https://peteroshaughnessy.com">Peter O'Shaughnessy</a></li>
 					<li><a href="https://christianoliff.com">Christian Oliff</a></li>
 					<li><a href="https://twitter.com/yevhenorlov">Yevhen Orlov</a></li>
 					<li><a href="https://twitter.com/okor">Jason Ormand</a></li>

--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
 					<li><a href='https://nilsnh.no'>Nils Norman Haukås</a></li>
 					<li><a href='https://pxlnv.com'>Nick Heer</a></li>
 					<li><a href='https://marcus.io'>Marcus Herrmann</a></li>
+					<li><a href='http://martynhoyer.co.uk'>Martyn Hoyer</a></li>
 					<li><a href='https://shanehudson.net'>Shane Hudson</a></li>
 					<li><a href='https://ghughes.com'>Greg Hughes</a></li>
 					<li><a href='https://blog.comandeer.pl'>Tomasz Jakut</a></li>


### PR DESCRIPTION
Looks like some auto-formatting took place at some point, which converted a few names which have apostrophes into names with double quote marks.
