### PR TITLE
Bran van der Meer

### DIFF
--- a/_data/supporting/bran-van-der-meer.yml
+++ b/_data/supporting/bran-van-der-meer.yml
@@ -1,0 +1,3 @@
+sortName: Meer
+displayName: Bran van der Meer
+url: http://bran.name/


### PR DESCRIPTION
To address the obvious `sortName` question; yes the `sortName` should be Meer, since that's [how Dutch names are sorted](https://en.wikipedia.org/wiki/Dutch_name#Surnames):

> in the Netherlands, the prefixes are always ignored for sorting (e.g., Van Rijn is ordered under 'R', but written in full. So a listing would be Raamdonck, Van Rijn, Rutgers and not Vaandrig, Van Rijn, Vondel)