### PR TITLE
Fix Stefan du Fresne sort

### DIFF
--- a/_data/supporting/stefan-du-fresne.yml
+++ b/_data/supporting/stefan-du-fresne.yml
@@ -1,3 +1,3 @@
-sortname: Dufresne
+sortName: Dufresne
 displayName: Stefan du Fresne
 url: http://sdufresne.info


### PR DESCRIPTION
Stefan du Fresne is listed first, because `sortName` is missing (used `sortname` instead).